### PR TITLE
add bounds check to EnumSections

### DIFF
--- a/ActiveProcesses.cpp
+++ b/ActiveProcesses.cpp
@@ -194,7 +194,7 @@ void __fastcall TFActiveProcesses::EnumSections(HANDLE HProcess, BYTE* PProcessB
     memset((BYTE*)&_section, 0, sizeof(_section));
 
     *Secnum = _ntHdr.FileHeader.NumberOfSections; _pBuf = (BYTE*)Buffer;
-    for (i = 0; i < _ntHdr.FileHeader.NumberOfSections; i++)
+    for (i = 0; i < _ntHdr.FileHeader.NumberOfSections && i < 64; i++)
     {
         if (!ReadProcessMemory(HProcess, _pSection + i * sizeof(_section), &_section, sizeof(_section), &_sz)) return;
         memmove(_pBuf, &_section, sizeof(_section));


### PR DESCRIPTION
The caller passes along an array of sections on the stack that can hold 64 sections. There was no check to see if more than 64 sections get read into this array, which could trigger stack corruption. A bounds check was added to make sure no more than 64 sections are written.